### PR TITLE
0.7.0 snapshots no-longer exist - use the release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.cloudhoist</groupId>
     <artifactId>pallet-crate-pom</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.7.0</version>
   </parent>
   <artifactId>haproxy</artifactId>
   <version>0.7.0-SNAPSHOT</version>


### PR DESCRIPTION
This crate seems to work fine with 0.7.2 and 0.7.3-SNAPSHOT with just this small change to remove the dependency on pallet 0.7.0-SNAPSHOT, which no-longer exist on sonatype. Installed this locally and all seems fine using the 0.7.0 release instead. I guess it could probably actually use 0.7.2?

Also, minor note - there aren't any published jars for this crate on sonatype that work with the current pallet releases. Is it possible to push out either a snapshot or release that works with 0.7.x?

Thanks!
